### PR TITLE
change links from github to gitlab, add Sprint

### DIFF
--- a/CORE_APPS.md
+++ b/CORE_APPS.md
@@ -2,26 +2,26 @@
 
 ## Core apps and their maintainers
 
-- [Calculator](https://gitlab.com/ubports/app-dev/calculator-app): [Brian Douglass](https://github.com/bhdouglass)
+- [Calculator](https://gitlab.com/ubports/app-dev/calculator-app): [Brian Douglass](https://gitlab.com/bhdouglass)
 - [Calendar](https://github.com/ubports/calendar-app): [Johannes Renkl](https://github.com/hummlbach)
 - [Camera](https://github.com/ubports/camera-app): [Eran Uzan](https://github.com/dark-eye)
 - [Clock](https://github.com/ubports/clock-app): [Eran Uzan](https://github.com/dark-eye)
 - [Contacts](https://github.com/ubports/address-book-app): [Alberto Mardegan](https://github.com/mardy)
 - [Dialer](https://github.com/ubports/dialer-app): [Eran Uzan](https://github.com/dark-eye)
-- [Doc Viewer](https://github.com/ubports/docviewer-app): [Chris Clime](https://github.com/balcy)
+- [Doc Viewer](https://gitlab.com/ubports/app-dev/docviewer-app): [Chris Clime](https://gitlab.com/balcy)
 - [File Manager](https://github.com/ubports/filemanager-app): [Bjarne Roß](https://github.com/nfsprodriver)
-- [Gallery](https://github.com/ubports/gallery-app): [Emanuele Sorce](https://github.com/TronFortyTwo)
+- [Gallery](https://gitlab.com/ubports/app-dev/gallery-app): [Emanuele Sorce](https://gitlab.com/TronFortyTwo)
 - [OpenStore](https://github.com/UbuntuOpenStore/openstore-app): [Brian Douglass](https://github.com/bhdouglass)
 - [Telegram](https://github.com/ubports/telegram-app): [Florian Leeber](https://github.com/Flohack74)
 - [Terminal](https://github.com/ubports/terminal-app): [Walter Garcia-Fontes](https://github.com/wagafo)
-- [UBports Welcome App](https://github.com/ubports/ubports-app): [Jan Sprinz](https://github.com/NeoTheThird)
+- [UBports Welcome App](https://gitlab.com/ubports/app-dev/ubports-app): [Jan Sprinz](https://gitlab.com/NeoTheThird)
 
 ## Core apps without maintainers
 
 - [Media Player](https://github.com/ubports/mediaplayer-app)
 - [Messenger](https://github.com/ubports/messaging-app)
 - [Morph Browser](https://github.com/ubports/morph-browser)
-- [Music](https://github.com/ubports/music-app)
+- [Music](https://gitlab.com/ubports/app-dev/music-app)
 - [Notes](https://github.com/ubports/notes-app)
 - [Printing](https://github.com/ubports/ubuntu-printing-app)
-- [Weather](https://github.com/ubports/weather-app)
+- [Weather](https://gitlab.com/ubports/app-dev/weather-app)


### PR DESCRIPTION
### Description of the Change

Just changed in the CORE_APPS.md the links from github to gitlab ~and added the Sprint app to the list~.

### Benefits

keep the list up to date

### Possible Drawbacks

Maybe the maintainers also changed? Should be changed then also.

### QA-Steps
### Related Issues