### PR TITLE
links now point to actively developed gitlab repo rather than archived github repos.

### DIFF
--- a/CORE_APPS.md
+++ b/CORE_APPS.md
@@ -4,13 +4,13 @@
 
 - [Calculator](https://gitlab.com/ubports/apps/calculator-app): [Brian Douglass](https://gitlab.com/bhdouglass)
 - [Calendar](https://gitlab.com/ubports/apps/calendar-app): [fuseteam](https://gitlab.com/XiaoFuse)
-- [Contacts](https://github.com/ubports/address-book-app): [Alberto Mardegan](https://github.com/mardy)
+- [Contacts](https://gitlab.com/ubports/core/address-book-app): [Alberto Mardegan](https://github.com/mardy)
 - [Dialer](https://github.com/ubports/dialer-app): [Lionel Duboeuf](https://github.com/lduboeuf)
 - [Doc Viewer](https://gitlab.com/ubports/apps/docviewer-app): [Chris Clime](https://gitlab.com/balcy)
 - [File Manager](https://gitlab.com/ubports/apps/filemanager-app): [Bjarne Roß](https://gitlab.com/nfsprodriver)
 - [Gallery](https://gitlab.com/ubports/apps/gallery-app): [Emanuele Sorce](https://gitlab.com/TronFortyTwo)
 - [Messenger](https://github.com/ubports/messaging-app): [Lionel Duboeuf](https://github.com/lduboeuf)
-- [Morph Browser](https://github.com/ubports/morph-browser): [Chris Clime](https://gitlab.com/balcy)
+- [Morph Browser](https://gitlab.com/ubports/core/morph-browser): [Chris Clime](https://gitlab.com/balcy)
 - [Notes](https://gitlab.com/ubports/apps/notes-app): [David Farkas](https://gitlab.com/farkasdvd)
 - [OpenStore](https://gitlab.com/theopenstore/openstore-app): [Brian Douglass](https://gitlab.com/bhdouglass)
 - [TELEports](https://gitlab.com/ubports/apps/teleports): [Florian Leeber](https://gitlab.com/Flohack74)
@@ -22,7 +22,7 @@
 ## Core apps seeking maintainers
 
 - [Camera](https://gitlab.com/ubports/apps/camera-app)
-- [Clock](https://github.com/ubports/clock-app)
+- [Clock](https://gitlab.com/ubports/apps/clock-app)
 - [Media Player](https://github.com/ubports/mediaplayer-app)
 - [Music](https://gitlab.com/ubports/apps/music-app)
 - [Printing](https://github.com/ubports/ubuntu-printing-app)


### PR DESCRIPTION


### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
corrected the repo linksto  point actively developed gitlab repo rather than archived github repos.


### Benefits
People will not land in on archived repo pages & think the the code is no longer maintained.

### Possible Drawbacks
Nothing that I can think of.

### QA-Steps
Tested it clicking on links and verifying that it points to correct repo.
